### PR TITLE
Update ResumptionToken.pm

### DIFF
--- a/lib/HTTP/OAI/ResumptionToken.pm
+++ b/lib/HTTP/OAI/ResumptionToken.pm
@@ -27,7 +27,7 @@ sub generate {
 sub end_element {
 	my ($self,$hash) = @_;
 	$self->SUPER::end_element($hash);
-	if( lc($hash->{Name}) eq 'resumptiontoken' ) {
+	if( lc($hash->{LocalName}) eq 'resumptiontoken' ) {
 		$self->resumptionToken($hash->{Text});
 
 		my $attr = $hash->{Attributes};


### PR DESCRIPTION
Should use the un-prefixed name (ie. LocalName) otherwise HTTP::OAI fails to capture the resumptionToken where the elements are prefixed (oai:resumptionToken/).
