### PR TITLE
don't die if onRecord is undef

### DIFF
--- a/lib/HTTP/OAI/Harvester.pm
+++ b/lib/HTTP/OAI/Harvester.pm
@@ -56,7 +56,7 @@ sub _list
 		last RESUME if !$token->resumptionToken;
 		local $self->{recursion};
 		$r = $self->_oai(
-			$r->{onRecord},
+			onRecord => $r->{onRecord},
 			handlers => $r->handlers,
 			verb => $r->verb,
 			resumptionToken => $token->resumptionToken,


### PR DESCRIPTION
If `onRecord` was not defined, https://metacpan.org/source/TIMBRODY/HTTP-OAI-4.03/lib/HTTP/OAI/UserAgent.pm#L31 died.
